### PR TITLE
Added settings for publishing to bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
 
 task sourcesJar(type: Jar, dependsOn: project.classes) {
     classifier = 'sources'
@@ -44,7 +45,30 @@ publishing {
     }
 }
 
+bintray {
+    dryRun = true
+    publish = false
 
+    user = findProperty("protoBintrayUser")
+    key = findProperty("protoBintrayKey")
+
+    publications = ['maven']
+    pkg {
+        repo = 'protoactor'
+        userOrg = 'protoactor'
+        name = project.name
+        websiteUrl = "http://proto.actor/"
+        vcsUrl = "https://github.com/AsynkronIT/protoactor-kotlin.git"
+        licenses = ['Apache-2.0']
+        labels = ['actor']
+        version {
+            gpg {
+                sign = false //Determines whether to GPG sign the files. The default is false
+                // passphrase = 'passphrase' //Optional. The passphrase for GPG signing'
+            }
+        }
+    }
+}
 
 class ArtifactExtension {
     String name = 'Proto.Actor'


### PR DESCRIPTION
Basic support for publishing to bintray that can handle publishing to jcenter, maven-central and snapshots to oss.jfrog.org.

Bintray is configured in dryRun mode and that needs to changed before being able to publish.

User and Key needs to be passed to the gradle script via an environment variable or as a gradle property:
http://mrhaki.blogspot.se/2016/05/gradle-goodness-get-property-or-default.html

@rogeralsing a bintray account needs to be setup @rogeralsing and linked to jcenter.

Versioning is not covered by this PR so the version need to be bumped manually.

Regarding publishing to maven central there are a couple of thing that needs to be done but can be deferred:
- Signing, this can be handled by bintray
- Documentation need to published, at the moment we're only publishing the jar and sources. This can be done with https://github.com/Kotlin/dokka
- It's recommended to not require alternative repositories like
```
        maven {
            url 'http://dl.bintray.com/kotlin/kotlin-eap-1.2'
        }
```
https://maven.apache.org/guides/mini/guide-central-repository-upload.html