### PR TITLE
Don't publish unstable versions to Bintray on every commit

### DIFF
--- a/build-via-travis.sh
+++ b/build-via-travis.sh
@@ -7,10 +7,11 @@ GRADLE_VERSION=$(./gradlew -version | grep Gradle | cut -d ' ' -f 2)
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew build $SWITCHES
+  ./gradlew check $SWITCHES
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -Prelease.travisci=true devSnapshot $SWITCHES
+  # We should publish unstable versions to OJO when the integration is working
+  ./gradlew check $SWITCHES
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
@@ -23,7 +24,7 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   esac
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
-  ./gradlew build $SWITCHES
+  ./gradlew check $SWITCHES
 fi
 
 EXIT=$?


### PR DESCRIPTION
We should publish beta versions to OJO later but the integration is broken at the moment.