### PR TITLE
Remove artifactory when not running snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,12 @@ configure(subprojects - project(':examples')) {
     check.dependsOn jacocoTestReport
 }
 
+gradle.taskGraph.whenReady { graph ->
+    tasks.artifactoryPublish.onlyIf {
+        graph.hasTask(':snapshot')
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '4.3.1'
 }


### PR DESCRIPTION
Artifactory was registered to the root project as well, that caused the bintray publishing to hang.
