### PR TITLE
Kotlin 1.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,8 @@
 buildscript {
-    ext.kotlin_version = '1.2.0-rc-39'
+    ext.kotlin_version = '1.2.0'
 
     repositories {
         jcenter()
-        maven {
-            url 'http://dl.bintray.com/kotlin/kotlin-eap-1.2'
-        }
     }
 
     dependencies {
@@ -35,9 +32,6 @@ subprojects {
 
     repositories {
         jcenter()
-        maven {
-            url 'http://dl.bintray.com/kotlin/kotlin-eap-1.2'
-        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ subprojects {
     compileKotlin {
         kotlinOptions {
             jvmTarget = "1.8"
+            allWarningsAsErrors = true
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 17 13:24:32 CET 2017
+#Tue Nov 28 21:01:21 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip

--- a/proto-actor/src/test/kotlin/actor/proto/tests/SupervisionTests_OneForOne.kt
+++ b/proto-actor/src/test/kotlin/actor/proto/tests/SupervisionTests_OneForOne.kt
@@ -94,7 +94,7 @@ class SupervisionTests_OneForOne {
 
     @Test fun `Should pass exception on restart`() {
         val childMailboxStats: TestMailboxStatistics = TestMailboxStatistics { it is Stopped }
-        val strategy: OneForOneStrategy = OneForOneStrategy({ pid, reason -> SupervisorDirective.Restart }, 1, null)
+        val strategy: OneForOneStrategy = OneForOneStrategy({ _, _ -> SupervisorDirective.Restart }, 1, null)
         val childProps: Props = fromProducer { ChildActor() }.withMailbox { newUnboundedMailbox(arrayOf(childMailboxStats)) }
         val parentProps: Props = fromProducer { ParentActor(childProps) }.withChildSupervisorStrategy(strategy)
         val parent: PID = spawn(parentProps)
@@ -108,7 +108,7 @@ class SupervisionTests_OneForOne {
 
     @Test fun `Should stop child when restart limit has been reached`() {
         val childMailboxStats: TestMailboxStatistics = TestMailboxStatistics { it is Stopped }
-        val strategy: OneForOneStrategy = OneForOneStrategy({ pid, reason -> SupervisorDirective.Restart }, 1, null)
+        val strategy: OneForOneStrategy = OneForOneStrategy({ _, _ -> SupervisorDirective.Restart }, 1, null)
         val childProps: Props = fromProducer { ChildActor() }.withMailbox { newUnboundedMailbox(arrayOf(childMailboxStats)) }
         val parentProps: Props = fromProducer { ParentActor(childProps) }.withChildSupervisorStrategy(strategy)
         val parent: PID = spawn(parentProps)

--- a/proto-mailbox/src/main/kotlin/actor/proto/mailbox/MailboxProducers.kt
+++ b/proto-mailbox/src/main/kotlin/actor/proto/mailbox/MailboxProducers.kt
@@ -4,8 +4,6 @@ import org.jctools.queues.*
 import org.jctools.queues.QueueFactory.newQueue
 import org.jctools.queues.atomic.*
 import org.jctools.queues.spec.ConcurrentQueueSpec
-import org.jctools.queues.spec.Ordering
-import org.jctools.queues.spec.Preference
 import java.util.concurrent.ConcurrentLinkedQueue
 
 private val emptyStats : Array<MailboxStatistics> = arrayOf()
@@ -22,6 +20,6 @@ fun newMpscGrowableArrayMailbox(initialCapacity: Int = 5, stats: Array<MailboxSt
 fun newMpscGrowableAtomicArrayMailbox(initialCapacity: Int = 5, stats: Array<MailboxStatistics> = emptyStats): Mailbox = DefaultMailbox(ConcurrentLinkedQueue<Any>(), MpscGrowableAtomicArrayQueue(initialCapacity, 2 shl 11), stats)
 
 
-fun newMpscLinkedMailbox(capacity: Int = 5, stats: Array<MailboxStatistics> = emptyStats): Mailbox = DefaultMailbox(ConcurrentLinkedQueue<Any>(), MpscLinkedQueue8(), stats)
+fun newMpscLinkedMailbox(stats: Array<MailboxStatistics> = emptyStats): Mailbox = DefaultMailbox(ConcurrentLinkedQueue<Any>(), MpscLinkedQueue8(), stats)
 
 fun newSpecifiedMailbox(spec:ConcurrentQueueSpec, stats: Array<MailboxStatistics> = emptyStats): Mailbox = DefaultMailbox(ConcurrentLinkedQueue<Any>(), newQueue(spec) , stats)


### PR DESCRIPTION
Upgrades kotlin to 1.2.0 and removes the EAP repository

Warnings are now treated as errors and unused variables has been removed. 