### PR TITLE
On restart resume mailbox after starting

### DIFF
--- a/proto-actor/src/main/kotlin/actor/proto/ActorContext.kt
+++ b/proto-actor/src/main/kotlin/actor/proto/ActorContext.kt
@@ -268,8 +268,8 @@ class ActorContext(private val producer: () -> Actor, override val self: PID, pr
 
     suspend private fun restart() {
         incarnateActor()
-        sendSystemMessage(self,ResumeMailbox)
         invokeUserMessage(Started)
+        sendSystemMessage(self,ResumeMailbox)
         while (stash.isNotEmpty()) invokeUserMessage(stash.pop())
     }
 

--- a/proto-actor/src/test/kotlin/actor/proto/tests/ActorTests.kt
+++ b/proto-actor/src/test/kotlin/actor/proto/tests/ActorTests.kt
@@ -64,4 +64,37 @@ class ActorTests {
         assertTrue(messageArr[2] is Stopping)
         assertTrue(messageArr[3] is Stopped)
     }
+
+    @Test fun actorStartedException(): Unit {
+        val numberExceptions = 2
+        var exceptionCount = 0
+        val messages: Queue<Any> = ArrayDeque<Any>()
+        val prop = fromFunc { msg ->
+            messages.offer(msg)
+            when (msg) {
+                is Started -> {
+                    exceptionCount++
+                    if (exceptionCount <= 2) throw Exception()
+                }
+                else -> {
+
+                }
+            }
+        }
+        val pid: PID = spawn(prop)
+        send(pid,"hello")
+        Thread.sleep(100)
+        stop(pid)
+        Thread.sleep(100)
+        assertEquals(8, messages.count())
+        val messageArr: Array<Any> = messages.toTypedArray()
+        assertTrue(messageArr[0] is Started)
+        assertTrue(messageArr[1] is Restarting)
+        assertTrue(messageArr[2] is Started)
+        assertTrue(messageArr[3] is Restarting)
+        assertTrue(messageArr[4] is Started)
+        assertTrue(messageArr[5] is String)
+        assertTrue(messageArr[6] is Stopping)
+        assertTrue(messageArr[7] is Stopped)
+    }
 }


### PR DESCRIPTION
Currently if an exception is thrown while processing the Started message, other user messages will be delivered before a successful start. This pull request delays resuming the mailbox until after Started is sent to the actor, changing this behaviour. Other user messages are only delivered once the actor has completed processing the Started message.

See issue #31 