### PR TITLE
Use kotlin-logging as slf4j-api wrapper (issue 34)

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -6,6 +6,7 @@ mainClassName = "actor.proto.examples.inprocessbenchmark.InProcessBenchmarkKt"
 dependencies {
     compile 'org.jctools:jctools-core:2.1.1'
     compile 'com.google.protobuf:protobuf-java:+'
+    compile 'org.slf4j:slf4j-simple:1.7.7'
 
     compile project(':proto-actor')
     compile project(':proto-router')

--- a/proto-actor/build.gradle
+++ b/proto-actor/build.gradle
@@ -13,4 +13,7 @@ jar {
 dependencies {
     compile group: 'com.google.protobuf', name: 'protobuf-java', version:'+'
     compile project(':proto-mailbox')
+    compile 'io.github.microutils:kotlin-logging:1.4.9'
+
+    testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }

--- a/proto-actor/src/main/kotlin/actor/proto/ActorContext.kt
+++ b/proto-actor/src/main/kotlin/actor/proto/ActorContext.kt
@@ -5,9 +5,10 @@ import actor.proto.mailbox.ResumeMailbox
 import actor.proto.mailbox.SuspendMailbox
 import actor.proto.mailbox.SystemMessage
 import kotlinx.coroutines.experimental.runBlocking
+import mu.KotlinLogging
 import java.time.Duration
 import java.util.*
-
+private val logger = KotlinLogging.logger {}
 class ActorContext(private val producer: () -> Actor, override val self: PID, private val supervisorStrategy: SupervisorStrategy, receiveMiddleware: List<ReceiveMiddleware>, senderMiddleware: List<SenderMiddleware>, override val parent: PID?) : MessageInvoker, Context, SenderContext, Supervisor {
     override var children: Set<PID> = setOf()
     private var watchers: Set<PID> = setOf()
@@ -233,7 +234,7 @@ class ActorContext(private val producer: () -> Actor, override val self: PID, pr
     }
 
     private fun handleRootFailure(failure: Failure) {
-        println("Handling root failure for " + failure.who.toShortString())
+        logger.warn("Handling root failure for " + failure.who.toShortString())
         Supervision.defaultStrategy.handleFailure(this, failure.who, failure.restartStatistics, failure.reason)
     }
 

--- a/proto-actor/src/main/kotlin/actor/proto/AllForOneStrategy.kt
+++ b/proto-actor/src/main/kotlin/actor/proto/AllForOneStrategy.kt
@@ -1,29 +1,30 @@
 package actor.proto
 
+import mu.KotlinLogging
 import java.time.Duration
-
+private val logger = KotlinLogging.logger {}
 class AllForOneStrategy(private val decider: (PID, Exception) -> SupervisorDirective, private val maxNrOfRetries: Int, private val withinTimeSpan: Duration?) : SupervisorStrategy {
     override fun handleFailure(supervisor: Supervisor, child: PID, rs: RestartStatistics, reason: Exception) {
         val directive: SupervisorDirective = decider(child, reason)
         when (directive) {
             SupervisorDirective.Resume -> {
-                Logger.logInformation("Resuming ${child.toShortString()} Reason $reason")
+                logger.debug("Resuming ${child.toShortString()} Reason $reason")
                 supervisor.resumeChildren(child)
             }
             SupervisorDirective.Restart -> {
                 when {
                     requestRestartPermission(rs) -> {
-                        Logger.logInformation("Restarting ${child.toShortString()} Reason $reason")
+                        logger.debug("Restarting ${child.toShortString()} Reason $reason")
                         supervisor.restartChildren(reason, *supervisor.children.toTypedArray())
                     }
                     else -> {
-                        Logger.logInformation("Stopping ${child.toShortString()} Reason $reason")
+                        logger.debug("Stopping ${child.toShortString()} Reason $reason")
                         supervisor.stopChildren(*supervisor.children.toTypedArray())
                     }
                 }
             }
             SupervisorDirective.Stop -> {
-                Logger.logInformation("Stopping ${child.toShortString()} Reason $reason")
+                logger.debug("Stopping ${child.toShortString()} Reason $reason")
                 supervisor.stopChildren(*supervisor.children.toTypedArray())
             }
             SupervisorDirective.Escalate -> {

--- a/proto-actor/src/main/kotlin/actor/proto/EventStream.kt
+++ b/proto-actor/src/main/kotlin/actor/proto/EventStream.kt
@@ -1,13 +1,14 @@
 package actor.proto
 
 import actor.proto.mailbox.Dispatchers
+import mu.KotlinLogging
 
-
+private val logger = KotlinLogging.logger {}
 object EventStream : EventStreamImpl() {
     init {
         subscribe({
             when (it) {
-                is DeadLetterEvent -> Logger.logInformation("[DeadLetter] '${it.pid.toShortString()}' got '${it.message.javaClass.name}:${it.message}' from '${it.sender?.toShortString()}'")
+                is DeadLetterEvent -> logger.warn("[DeadLetter] '${it.pid.toShortString()}' got '${it.message.javaClass.name}:${it.message}' from '${it.sender?.toShortString()}'")
             }
         }, Dispatchers.SYNCHRONOUS_DISPATCHER)
     }

--- a/proto-remote/build.gradle
+++ b/proto-remote/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     compile group: 'io.grpc', name: 'grpc-netty', version:'1.7.0'
     compile group: 'io.grpc', name: 'grpc-protobuf', version:'1.7.0'
     compile group: 'io.grpc', name: 'grpc-stub', version:'1.7.0'
+    compile 'io.github.microutils:kotlin-logging:1.4.9'
     compile project(':proto-actor')
     compile project(':proto-mailbox')
+
+    testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }

--- a/proto-remote/src/main/kotlin/actor/proto/remote/EndpointManager.kt
+++ b/proto-remote/src/main/kotlin/actor/proto/remote/EndpointManager.kt
@@ -1,14 +1,16 @@
 package actor.proto.remote
 
 import actor.proto.*
+import mu.KotlinLogging
 
+private val logger = KotlinLogging.logger {}
 class EndpointManager(private val config: RemoteConfig) : Actor, SupervisorStrategy {
 
 
     private val _connections: HashMap<String, Endpoint> = HashMap()
     suspend override fun Context.receive(msg: Any) {
         when (msg) {
-            is Started -> println("Started EndpointManager")
+            is Started -> logger.info("Started EndpointManager")
             is EndpointTerminatedEvent ->  ensureConnected(msg.address).watcher.let { send(it,msg) }
             is RemoteTerminate -> ensureConnected(msg.watchee.address).watcher.let {send(it,msg) }
             is RemoteWatch -> ensureConnected(msg.watchee.address).watcher.let { send(it,msg) }

--- a/proto-remote/src/main/kotlin/actor/proto/remote/EndpointReader.kt
+++ b/proto-remote/src/main/kotlin/actor/proto/remote/EndpointReader.kt
@@ -3,7 +3,9 @@ package actor.proto.remote
 import actor.proto.*
 import actor.proto.mailbox.SystemMessage
 import io.grpc.stub.StreamObserver
+import mu.KotlinLogging
 
+private val logger = KotlinLogging.logger {}
 class EndpointReader : RemotingGrpc.RemotingImplBase() {
     override fun connect(request: RemoteProtos.ConnectRequest, responseObserver: StreamObserver<RemoteProtos.ConnectResponse>) {
         responseObserver.onNext(ConnectResponse(Serialization.defaultSerializerId))
@@ -13,7 +15,7 @@ class EndpointReader : RemotingGrpc.RemotingImplBase() {
     override fun receive(responseObserver: StreamObserver<RemoteProtos.Unit>): StreamObserver<RemoteProtos.MessageBatch> {
         return object : StreamObserver<RemoteProtos.MessageBatch> {
             override fun onCompleted() = responseObserver.onCompleted()
-            override fun onError(err: Throwable): Unit = println(err)
+            override fun onError(err: Throwable): Unit = logger.error("Stream observer exception",err)
             override fun onNext(batch: RemoteProtos.MessageBatch) = receiveBatch(batch)
         }
     }

--- a/proto-remote/src/main/kotlin/actor/proto/remote/EndpointWriter.kt
+++ b/proto-remote/src/main/kotlin/actor/proto/remote/EndpointWriter.kt
@@ -5,7 +5,9 @@ import com.google.protobuf.ByteString
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.grpc.stub.StreamObserver
+import mu.KotlinLogging
 
+private val logger = KotlinLogging.logger {}
 class EndpointWriter(private val address: String) : Actor {
     private var serializerId: Int = 0
     private lateinit var channel: ManagedChannel
@@ -59,7 +61,7 @@ class EndpointWriter(private val address: String) : Actor {
             streamWriter.onNext(batch)
         } catch (x: Exception) {
             stash()
-            println("gRPC Failed to send to address $address, reason ${x.message}")
+            logger.error("gRPC Failed to send to address $address, reason ${x.message}")
             throw  x
         }
     }
@@ -67,7 +69,7 @@ class EndpointWriter(private val address: String) : Actor {
     private suspend fun restarting() = channel.shutdownNow()
     private suspend fun stopped() = channel.shutdownNow()
     private suspend fun started() {
-        println("Connecting to address $address")
+        logger.info("Connecting to address $address")
         val (host, port) = parseAddress(address)
         channel = ManagedChannelBuilder
                 .forAddress(host, port)
@@ -92,7 +94,7 @@ class EndpointWriter(private val address: String) : Actor {
 //            }
 //        }
 
-        println("Connected to address $address")
+        logger.info("Connected to address $address")
     }
 }
 

--- a/proto-remote/src/main/kotlin/actor/proto/remote/Remote.kt
+++ b/proto-remote/src/main/kotlin/actor/proto/remote/Remote.kt
@@ -4,8 +4,9 @@ import actor.proto.*
 import actor.proto.mailbox.newMpscUnboundedArrayMailbox
 import io.grpc.Server
 import io.grpc.ServerBuilder
+import mu.KotlinLogging
 import java.time.Duration
-
+private val logger = KotlinLogging.logger {}
 object Remote {
     private lateinit var _server: Server
     private val Kinds: HashMap<String, Props> = HashMap()
@@ -31,7 +32,7 @@ object Remote {
         ProcessRegistry.address = address
         spawnEndpointManager(config)
         spawnActivator()
-        println("Starting Proto.Actor server on $boundAddress")
+        logger.info("Starting Proto.Actor server on $boundAddress")
     }
 
     private fun spawnActivator() {

--- a/proto-router/build.gradle
+++ b/proto-router/build.gradle
@@ -6,4 +6,6 @@ dependencies {
     compile project(':proto-actor')
     compile project(':proto-mailbox')
     compile 'com.google.protobuf:protobuf-java:+'
+
+    testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }


### PR DESCRIPTION
Use kotlin-logging as a slf4j-api wrapper to replace all println in production code.
Use slf4j-simple binding for tests and examples logging.