### PR TITLE
Reimplement original DefaultDispatcher constructor

### DIFF
--- a/proto-mailbox/build.gradle
+++ b/proto-mailbox/build.gradle
@@ -6,4 +6,6 @@ dependencies {
     api "org.jctools:jctools-core:${jctools_version}"
     implementation "org.slf4j:slf4j-api:${slf4j_version}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutines_version}"
+    testImplementation "org.slf4j:slf4j-simple:${slf4j_version}"
+    testImplementation "org.awaitility:awaitility:${awaitility_version}"
 }

--- a/proto-mailbox/src/main/kotlin/actor/proto/mailbox/DefaultDispatcher.kt
+++ b/proto-mailbox/src/main/kotlin/actor/proto/mailbox/DefaultDispatcher.kt
@@ -1,13 +1,22 @@
 package actor.proto.mailbox
 
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.plus
+import kotlin.coroutines.CoroutineContext
 
 
-class DefaultDispatcher( override var throughput: Int = 300) : Dispatcher {
+class DefaultDispatcher(context: CoroutineContext = Dispatchers.Default, override var throughput: Int = 300) : Dispatcher {
+    // We could create a jobless GlobalScope root scope and replace the default dispatcher with our dispatcher
+    // val scope : CoroutineScope = GlobalScope + context
+    //Or we can create a scope from our dispatcher with a default job, and replace it with a supervisor job.
+    //This way we get a normal scope that could be cancelled if needed
+    private val scope : CoroutineScope = CoroutineScope(context) + SupervisorJob()
+
     override fun schedule(mailbox:Mailbox) {
-
-        GlobalScope.launch {
+        scope.launch {
             mailbox.run()
         }
     }

--- a/proto-mailbox/src/test/kotlin/actor/proto/mailbox/DefaultDispatcherTest.kt
+++ b/proto-mailbox/src/test/kotlin/actor/proto/mailbox/DefaultDispatcherTest.kt
@@ -1,0 +1,74 @@
+package actor.proto.mailbox
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import org.awaitility.Awaitility
+import org.junit.Assert
+import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+class DefaultDispatcherTest {
+
+    @Test
+    fun coroutineScopeTest() {
+        val mailbox1 = TestMailbox(100, true)
+        val mailbox2 = TestMailbox(300, false)
+        val mailbox3 = TestMailbox(100, false)
+
+        val dispatcher1 = DefaultDispatcher()
+        val threadPool = Executors.newWorkStealingPool().asCoroutineDispatcher()
+        val dispatcher2 = DefaultDispatcher(threadPool, 300)
+
+        dispatcher1.schedule(mailbox1)
+        dispatcher1.schedule(mailbox2)
+        dispatcher2.schedule(mailbox3)
+
+
+        Awaitility.ignoreExceptionsByDefault()
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted {
+            Assert.assertTrue(mailbox1.completedRunning)
+            //if the exception in mailbox1 causes all child coroutines to cancel, then this will fail
+            Assert.assertTrue(mailbox2.completedRunning)
+            //mailboxes using same dispatcher should have same coroutine dispatcher
+            Assert.assertSame(mailbox1.runInContext?.get(ContinuationInterceptor.Key), mailbox2.runInContext?.get(ContinuationInterceptor.Key))
+            //but mailboxes with a different dispatcher have a different coroutine dispatcher
+            Assert.assertNotSame(mailbox1.runInContext?.get(ContinuationInterceptor.Key), mailbox3.runInContext?.get(ContinuationInterceptor.Key))
+        }
+    }
+}
+
+
+class TestMailbox(private val millis: Long, private val exception: Boolean) : Mailbox {
+
+    var runInContext: CoroutineContext? = null
+    var completedRunning : Boolean = false
+
+    override fun postSystemMessage(msg: Any) {
+
+    }
+
+    override fun registerHandlers(invoker: MessageInvoker, dispatcher: Dispatcher) {
+
+    }
+
+    override fun start() {
+
+    }
+
+    override suspend fun run() {
+        runInContext = coroutineContext
+        delay(millis)
+        completedRunning = true
+        if (exception) throw Exception()
+    }
+
+    override fun postUserMessage(msg: Any) {
+
+    }
+
+}


### PR DESCRIPTION
The DefaultDispatcher used to accept a custom CoroutineDispatcher in the constructor - this was removed during the December 2018 commits to upgrade kotlin, which just used GlobalScope for all DefaultDispatchers instantiated.

We use different thread pools for different actor types, mainly so that standard profiling gives a good indication of any blocking or performance problems for particular actors.

This commit reimplements the original DefaultDispatcher constructor.

For each DefaultDispatcher, a new Coroutine Scope is created from the provided context, and then a SupervisorJob is added. This provides the exception handling we need (an exception doesn't cause the parent scope or its children to cancel).

If no custom CoroutineDispatcher is provided, then the kotlin default (Dispatchers.Default) is used. This creates a Coroutine Scope using the same Coroutine Dispatcher as GlobalScope, but with a SupervisorJob instead of no Job.